### PR TITLE
Fix 2 code scanning alerts

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -46,7 +46,8 @@ public class SSRFTask2 extends AssignmentEndpoint {
   }
 
   protected AttackResult furBall(String url) {
-    if (url.matches("http://ifconfig\\.pro")) {
+    String validUrl = "http://ifconfig.pro";
+    if (validUrl.equals(url)) {
       String html;
       try (InputStream in = new URL(url).openStream()) {
         html =

--- a/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
@@ -97,10 +97,8 @@ public class CommentsCache {
     var jc = JAXBContext.newInstance(Comment.class);
     var xif = XMLInputFactory.newInstance();
 
-    if (webSession.isSecurityEnabled()) {
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
-    }
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
 
     var xsr = xif.createXMLStreamReader(new StringReader(xml));
 


### PR DESCRIPTION
Fixes 2 code scanning alerts:
- https://github.com/ctcampbellcom/webgoat-manual-codeql/security/code-scanning/46
To fix the SSRF vulnerability, we need to ensure that the user-provided URL is validated against a list of authorized URLs or restricted to a particular host or URL prefix. In this case, we can validate the URL against a known fixed string (`http://ifconfig.pro`) to ensure that only this specific URL is allowed.

  1. Modify the `furBall` method to validate the `url` parameter against a known fixed string.
  2. Ensure that the `url` parameter is only used if it matches the fixed string.
  


- https://github.com/ctcampbellcom/webgoat-manual-codeql/security/code-scanning/29
To fix the problem, we need to ensure that the XML parser is always securely configured to prevent XXE attacks, regardless of the `webSession.isSecurityEnabled()` condition. This involves setting the necessary properties on the `XMLInputFactory` to disable external entity resolution unconditionally.

  - Modify the `parseXml` method in `CommentsCache` class to always disable external entity resolution.
  - Ensure that the `XMLInputFactory` is securely configured by setting the properties `XMLConstants.ACCESS_EXTERNAL_DTD` and `XMLConstants.ACCESS_EXTERNAL_SCHEMA` to empty strings.
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._